### PR TITLE
max 3 lines for description

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ image: https://obsidian.md/images/banner.png
 ​```
 ```
 
+# Customizing Style
+Card-styled link is styled by [styles.css](./styles.css). To customize, you can try making [CSS snippets](https://help.obsidian.md/How+to/Add+custom+styles#Use+Themes+and+or+CSS+snippets).
 
 # Motivation
 - Wanted to show beautiful links in my notes

--- a/styles.css
+++ b/styles.css
@@ -52,13 +52,13 @@
 .auto-card-link-description {
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
+    -webkit-line-clamp: 3;
+    max-height: 4.65em;
     overflow-x: hidden;
     overflow-y: hidden;
     margin-top: 0.5em;
     color: #77838c;
     font-size: 0.8em !important;
-    max-height: 1.55em;
 }
 
 .auto-card-link-host {

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,4 @@
 .auto-card-link-container {
-    max-width: 780px;
     margin: 0 auto;
     border: solid 1px rgba(92, 147, 187, 0.2);
     border-radius: 8px;


### PR DESCRIPTION
updated style from request of https://github.com/nekoshita/obsidian-auto-card-link/issues/15
- max 3 lines for description
- update README.md

I tried to make it responsive using `@media` rule, but it did not work properly because it refers the width of Obsidian window, not the pane...
