### PR TITLE
Refactor by plugin review

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "obsidian": "^0.14.3",
     "prettier": "^2.6.1",
-    "typescript": "^4.6.3",
-    "yaml": "^2.0.0"
+    "typescript": "^4.6.3"
   }
 }

--- a/src/checkif.ts
+++ b/src/checkif.ts
@@ -1,18 +1,18 @@
-import { DEFAULT_SETTINGS } from "src/settings";
+import { urlRegex, linkRegex, imageRegex } from "src/regex";
 
 export class CheckIf {
   public static isUrl(text: string): boolean {
-    const urlRegex = new RegExp(DEFAULT_SETTINGS.regex);
-    return urlRegex.test(text);
+    const regex = new RegExp(urlRegex);
+    return regex.test(text);
   }
 
   public static isImage(text: string): boolean {
-    const imageRegex = new RegExp(DEFAULT_SETTINGS.imageRegex);
-    return imageRegex.test(text);
+    const regex = new RegExp(imageRegex);
+    return regex.test(text);
   }
 
   public static isLinkedUrl(text: string): boolean {
-    const urlRegex = new RegExp(DEFAULT_SETTINGS.linkRegex);
-    return urlRegex.test(text);
+    const regex = new RegExp(linkRegex);
+    return regex.test(text);
   }
 }

--- a/src/code_block_generator.ts
+++ b/src/code_block_generator.ts
@@ -1,4 +1,4 @@
-import { Editor, Notice } from "obsidian";
+import { Editor, Notice, requestUrl } from "obsidian";
 
 import { LinkMetadata } from "src/interfaces";
 import { EditorExtensions } from "src/editor_enhancements";
@@ -64,10 +64,11 @@ export class CodeBlockGenerator {
   ): Promise<LinkMetadata | undefined> {
     const data = await (async () => {
       try {
-        const res = await ajaxPromise({
-          url: `http://iframely.server.crestify.com/iframely?url=${url}`,
-        });
-        return JSON.parse(res);
+        return (
+          await requestUrl({
+            url: `http://iframely.server.crestify.com/iframely?url=${url}`,
+          })
+        ).json;
       } catch (e) {
         console.log(e);
         return;

--- a/src/code_block_processor.ts
+++ b/src/code_block_processor.ts
@@ -1,5 +1,4 @@
-import { App } from "obsidian";
-import * as Yaml from "yaml";
+import { App, parseYaml } from "obsidian";
 
 import { YamlParseError, NoRequiredParamsError } from "src/errors";
 import { LinkMetadata } from "src/interfaces";
@@ -30,7 +29,7 @@ export class CodeBlockProcessor {
     let yaml: Partial<LinkMetadata>;
 
     try {
-      yaml = Yaml.parse(source) as Partial<LinkMetadata>;
+      yaml = parseYaml(source) as Partial<LinkMetadata>;
     } catch (error) {
       console.log(error);
       throw new YamlParseError(

--- a/src/editor_enhancements.ts
+++ b/src/editor_enhancements.ts
@@ -1,6 +1,6 @@
 import { Editor, EditorPosition } from "obsidian";
 
-import { DEFAULT_SETTINGS } from "src/settings";
+import { linkLineRegex, lineRegex } from "src/regex";
 
 interface WordBoundaries {
   start: { line: number; ch: number };
@@ -32,7 +32,7 @@ export class EditorExtensions {
     // In this case we can simply overwrite the link boundaries as-is
     const lineText = editor.getLine(cursor.line);
     // First check if we're in a link
-    const linksInLine = lineText.matchAll(DEFAULT_SETTINGS.linkLineRegex);
+    const linksInLine = lineText.matchAll(linkLineRegex);
 
     for (const match of linksInLine) {
       if (this.isCursorWithinBoundaries(cursor, match)) {
@@ -48,7 +48,7 @@ export class EditorExtensions {
     }
 
     // If not, check if we're in just a standard ol' URL.
-    const urlsInLine = lineText.matchAll(DEFAULT_SETTINGS.lineRegex);
+    const urlsInLine = lineText.matchAll(lineRegex);
 
     for (const match of urlsInLine) {
       if (this.isCursorWithinBoundaries(cursor, match)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { EditorExtensions } from "src/editor_enhancements";
 import { CheckIf } from "src/checkif";
 import { CodeBlockGenerator } from "src/code_block_generator";
 import { CodeBlockProcessor } from "src/code_block_processor";
+import { linkRegex } from "src/regex";
 
 export default class ObsidianAutoCardLink extends Plugin {
   settings?: ObsidianAutoCardLinkSettings;
@@ -83,6 +84,9 @@ export default class ObsidianAutoCardLink extends Plugin {
       editor.replaceSelection(clipboardText);
       return;
     }
+
+    console.log(clipboardText);
+    console.log(CheckIf.isUrl(clipboardText));
 
     // If not URL, just paste
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
@@ -165,7 +169,7 @@ export default class ObsidianAutoCardLink extends Plugin {
   }
 
   private getUrlFromLink(link: string): string {
-    const urlRegex = new RegExp(DEFAULT_SETTINGS.linkRegex);
+    const urlRegex = new RegExp(linkRegex);
     const regExpExecArray = urlRegex.exec(link);
     if (regExpExecArray === null || regExpExecArray.length < 2) {
       return "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, MarkdownView, Editor } from "obsidian";
+import { Plugin, MarkdownView, Editor, Menu, MenuItem } from "obsidian";
 
 import {
   ObsidianAutoCardLinkSettings,
@@ -51,39 +51,7 @@ export default class ObsidianAutoCardLink extends Plugin {
 
     this.registerEvent(this.app.workspace.on("editor-paste", this.onPaste));
 
-    this.registerEvent(
-      this.app.workspace.on("editor-menu", (menu) => {
-        // if showInMenuItem setting is false, now showing menu item
-        if (!this.settings?.showInMenuItem) return;
-
-        menu.addItem((item) => {
-          item
-            .setTitle("Paste URL and enhance to card link")
-            .setIcon("paste")
-            .onClick(async () => {
-              const editor = this.getEditor();
-              if (!editor) return;
-              this.manualPasteAndEnhanceURL(editor);
-            });
-        });
-
-        // if offline, not showing "Enhance selected URL to card link" item
-        if (!navigator.onLine) return;
-
-        menu.addItem((item) => {
-          item
-            .setTitle("Enhance selected URL to card link")
-            .setIcon("link")
-            .onClick(() => {
-              const editor = this.getEditor();
-              if (!editor) return;
-              this.enhanceSelectedURL(editor);
-            });
-        });
-
-        return;
-      })
-    );
+    this.registerEvent(this.app.workspace.on("editor-menu", this.onEditorMenu));
 
     this.addSettingTab(new ObsidianAutoCardLinkSettingTab(this.app, this));
   }
@@ -155,6 +123,38 @@ export default class ObsidianAutoCardLink extends Plugin {
 
     const codeBlockGenerator = new CodeBlockGenerator(editor);
     await codeBlockGenerator.convertUrlToCodeBlock(clipboardText);
+    return;
+  };
+
+  private onEditorMenu = (menu: Menu) => {
+    // if showInMenuItem setting is false, now showing menu item
+    if (!this.settings?.showInMenuItem) return;
+
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Paste URL and enhance to card link")
+        .setIcon("paste")
+        .onClick(async () => {
+          const editor = this.getEditor();
+          if (!editor) return;
+          this.manualPasteAndEnhanceURL(editor);
+        });
+    });
+
+    // if offline, not showing "Enhance selected URL to card link" item
+    if (!navigator.onLine) return;
+
+    menu.addItem((item: MenuItem) => {
+      item
+        .setTitle("Enhance selected URL to card link")
+        .setIcon("link")
+        .onClick(() => {
+          const editor = this.getEditor();
+          if (!editor) return;
+          this.enhanceSelectedURL(editor);
+        });
+    });
+
     return;
   };
 

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -1,0 +1,9 @@
+export const urlRegex =
+  /^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})$/i;
+export const lineRegex =
+  /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+export const linkRegex =
+  /^\[([^[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)$/i;
+export const linkLineRegex =
+  /\[([^[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)/gi;
+export const imageRegex = /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,25 +3,11 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import ObsidianAutoCardLink from "src/main";
 
 export interface ObsidianAutoCardLinkSettings {
-  regex: RegExp;
-  lineRegex: RegExp;
-  linkRegex: RegExp;
-  linkLineRegex: RegExp;
-  imageRegex: RegExp;
   showInMenuItem: boolean;
   enhanceDefaultPaste: boolean;
 }
 
 export const DEFAULT_SETTINGS: ObsidianAutoCardLinkSettings = {
-  regex:
-    /^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})$/i,
-  lineRegex:
-    /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi,
-  linkRegex:
-    /^\[([^[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)$/i,
-  linkLineRegex:
-    /\[([^[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)/gi,
-  imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
   showInMenuItem: true,
   enhanceDefaultPaste: false,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,8 +1067,3 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yaml@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0.tgz#cbc588ad58e0cd924cd3f5f2b1a9485103048e25"
-  integrity sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==


### PR DESCRIPTION
https://github.com/obsidianmd/obsidian-releases/pull/915

fixed problems below
- The editor object is passed to the editor-paste event, so you shouldn't have to get it manually.
- You shouldn't put objects here along with your settings, because the config object is serialized to JSON and deserialized from string. Why not just store them as a global constant like export const MY_REGEX = /..../;?
- Should use parseYAML from obsidian instead of bringing your own copy of a YAML parser.
- Consider using requestUrl from obsidian.


not yet fixed problems below
- In your readme file, you should mention which online service you're using to generate the link details, to avoid being criticized by privacy-concerned users.
  - -> will parse pure html, so that this plugin will not use any online service
- You should also check whether there are files in the clipboard - some browsers will paste images with the URL in the text/plain field but you're only catching it if the URL has an image extension.
  - I don't get the problem, so I'm going to ask about this later on the PR.