### PR TITLE
Parse html for getting link metadata instead of using iframely

### DIFF
--- a/src/link_metadata_parser.ts
+++ b/src/link_metadata_parser.ts
@@ -1,0 +1,69 @@
+import { LinkMetadata } from "src/interfaces";
+
+export class LinkMetadataParser {
+  url: string;
+  htmlDoc: Document;
+
+  constructor(url: string, htmlText: string) {
+    this.url = url;
+
+    const parser = new DOMParser();
+    const htmlDoc = parser.parseFromString(htmlText, "text/html");
+    this.htmlDoc = htmlDoc;
+  }
+
+  parse(): LinkMetadata | undefined {
+    const title = this.getTitle();
+    if (!title) return;
+
+    const description = this.getDescription();
+    const { hostname } = new URL(this.url);
+    const favicon = this.getFavicon();
+    const image = this.getImage();
+
+    return {
+      url: this.url,
+      title: title,
+      description: description,
+      host: hostname,
+      favicon: favicon,
+      image: image,
+    };
+  }
+
+  private getTitle(): string | undefined {
+    const ogTitle = this.htmlDoc
+      .querySelector("meta[property='og:title']")
+      ?.getAttr("content");
+    if (ogTitle) return ogTitle;
+
+    const title = this.htmlDoc.querySelector("title")?.textContent;
+    if (title) return title;
+  }
+
+  private getDescription(): string | undefined {
+    const ogDescription = this.htmlDoc
+      .querySelector("meta[property='og:description']")
+      ?.getAttr("content");
+    if (ogDescription) return ogDescription;
+
+    const metaDescription = this.htmlDoc
+      .querySelector("meta[name='description']")
+      ?.getAttr("content");
+    if (metaDescription) return metaDescription;
+  }
+
+  private getFavicon(): string | undefined {
+    const favicon = this.htmlDoc
+      .querySelector("link[rel='icon']")
+      ?.getAttr("href");
+    if (favicon) return favicon;
+  }
+
+  private getImage(): string | undefined {
+    const ogImage = this.htmlDoc
+      .querySelector("meta[property='og:image']")
+      ?.getAttr("content");
+    if (ogImage) return ogImage;
+  }
+}


### PR DESCRIPTION
This PR solves a problem below from plugin review(https://github.com/obsidianmd/obsidian-releases/pull/915) because this plugin does not use other services anymore
>In your readme file, you should mention which online service you're using to generate the link details, to avoid being criticized by privacy-concerned users.
