### PR TITLE
let default paste handler to take care the paste if clipboard includes any files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,9 @@ export default class ObsidianAutoCardLink extends Plugin {
 
     if (evt.clipboardData == null) return;
 
+    // If clipboardData includes any files, we return false to allow the default paste handler to take care of it.
+    if (evt.clipboardData.files.length > 0) return;
+
     const clipboardText = evt.clipboardData.getData("text/plain");
     if (clipboardText == null || clipboardText == "") return;
 


### PR DESCRIPTION
https://github.com/obsidianmd/obsidian-releases/pull/915

fixed a problem below
>You should also check whether there are files in the clipboard - some browsers will paste images with the URL in the text/plain field but you're only catching it if the URL has an image extension.