### PR TITLE
New card style

### DIFF
--- a/src/code_block_processor.ts
+++ b/src/code_block_processor.ts
@@ -98,12 +98,12 @@ export class CodeBlockProcessor {
     titleEl.textContent = data.title;
     mainEl.appendChild(titleEl);
 
-    const descriptionEl = document.createElement("div");
-    descriptionEl.addClass("auto-card-link-description");
     if (data.description) {
+      const descriptionEl = document.createElement("div");
+      descriptionEl.addClass("auto-card-link-description");
       descriptionEl.textContent = data.description;
+      mainEl.appendChild(descriptionEl);
     }
-    mainEl.appendChild(descriptionEl);
 
     const hostEl = document.createElement("div");
     hostEl.addClass("auto-card-link-host");
@@ -112,32 +112,23 @@ export class CodeBlockProcessor {
     if (data.favicon) {
       const faviconEl = document.createElement("img");
       faviconEl.addClass("auto-card-link-favicon");
-      if (data.favicon) {
-        faviconEl.setAttr("src", data.favicon);
-      }
-      faviconEl.setAttr("width", 14);
-      faviconEl.setAttr("height", 14);
-      faviconEl.setAttr("alt", "");
+      faviconEl.setAttr("src", data.favicon);
       hostEl.appendChild(faviconEl);
     }
 
-    const hostNameEl = document.createElement("span");
     if (data.host) {
+      const hostNameEl = document.createElement("span");
       hostNameEl.textContent = data.host;
+      hostEl.appendChild(hostNameEl);
     }
-    hostEl.appendChild(hostNameEl);
 
-    const thumbnailEl = document.createElement("div");
-    thumbnailEl.addClass("auto-card-link-thumbnail");
-    cardEl.appendChild(thumbnailEl);
-
-    const thumbnailImgEl = document.createElement("img");
-    thumbnailImgEl.addClass("auto-card-link-thumbnail-img");
     if (data.image) {
-      thumbnailImgEl.setAttr("src", data.image);
+      const thumbnailEl = document.createElement("img");
+      thumbnailEl.addClass("auto-card-link-thumbnail");
+      thumbnailEl.setAttr("src", data.image);
+      thumbnailEl.setAttr("draggable", "false");
+      cardEl.appendChild(thumbnailEl);
     }
-    thumbnailImgEl.setAttr("alt", "");
-    thumbnailEl.appendChild(thumbnailImgEl);
 
     return containerEl;
   }

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,13 @@
-.auto-card-link-container {
-    margin: 0 auto;
-    border: solid 1px rgba(92, 147, 187, 0.2);
-    border-radius: 8px;
-    overflow: hidden;
-    font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
-        "Helvetica Neue", Arial, sans-serif;
+.markdown-reading-view .block-language-cardlink {
+    margin: 1em 0;
 }
 
 .auto-card-link-container {
+    container-type: inline-size;
+    position: relative;
+    overflow: hidden;
+    user-select: none;
+
     --auto-card-link-indent-size: 2.5em;
 
     &[data-auto-card-link-depth="0"] {
@@ -36,81 +36,115 @@
     }
 }
 
+@container (max-width: 300px) {
+    .auto-card-link-thumbnail {
+        display: none;
+    }
+}
+
+@container (max-width: 500px) {
+    .auto-card-link-description {
+        display: none;
+    }
+    .auto-card-link-thumbnail {
+        max-width: 40% !important;
+    }
+    .auto-card-link-title {
+        white-space: normal !important;
+        --lh: 1.5em;
+        line-height: var(--lh);
+        height: calc(var(--lh) * 3);
+    }
+}
+
 .auto-card-link-error-container {
     max-width: 780px;
-    margin: 0 auto;
+    margin: 1em auto;
     border-radius: 8px;
     overflow: hidden;
-    font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
-        "Helvetica Neue", Arial, sans-serif;
-    background-color: rgb(255, 246, 228);
+    background-color: var(--background-modifier-error);
     padding: 10px;
+    font-family: var(--font-text);
+
+    &:hover {
+        background: var(--background-modifier-error-hover);
+    }
 }
 
 .auto-card-link-card {
     display: flex;
-    align-items: center;
-    height: 120px;
-    line-height: 1.5;
-    transition: 0.2s;
-    color: rgba(0, 0, 0, 0.82);
-    text-decoration: none;
-    background: #fff;
+    flex-direction: row-reverse;
+    height: 8em;
+    transition: 20ms ease-in 0s;
     cursor: pointer;
+    text-decoration: none;
+    color: var(--link-external-color);
+    background: var(--background-primary-alt);
+    border: solid var(--border-width) var(--divider-color);
+    border-radius: var(--radius-s);
+
+    &:hover {
+        background: var(--background-modifier-hover);
+        border-color: var(--background-modifier-hover);
+        text-decoration: none;
+    }
 }
 
 .auto-card-link-main {
-    flex: 1;
-    height: 100%;
-    padding: 0.25em 1.2em;
-    min-width: 0;
     display: flex;
+    flex-grow: 1;
     flex-direction: column;
-    justify-content: space-around;
+    justify-content: space-between;
+    gap: 0.18em;
+    padding: 0.5em 0.6em;
+    overflow: hidden;
+    text-align: left; /* necessary for ellipsis to work */
 }
 
 .auto-card-link-title {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
     overflow: hidden;
-    word-break: break-word;
-    margin: 0;
-    font-size: 1em !important;
-    user-select: none;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:hover {
+        color: var(--link-external-color-hover)
+    }
 }
 
 .auto-card-link-description {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    max-height: 4.65em;
     overflow: hidden;
-    color: #77838c;
-    font-size: 0.8em !important;
+    --lh: 1.4em;
+    line-height: var(--lh);
+    height: calc(var(--lh) * 3);
+    color: var(--text-muted);
+    font-size: var(--font-smallest);
 }
 
 .auto-card-link-host {
-    font-size: 0.78em !important;
+    font-size: var(--font-smallest);
     display: flex;
+    flex-direction: row;
     align-items: center;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+
+    &:hover {
+        color: var(--link-external-color-hover)
+    }
 }
 
 .auto-card-link-favicon {
-    margin-right: 8px;
-    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    margin: 0 0.5em 0 0 !important;
 }
 
 .auto-card-link-thumbnail {
-    height: 120px;
-    max-width: 230px;
+    border-radius: var(--radius-s) 0 0 var(--radius-s) !important;
+    height: 100%;
+    object-fit: cover;
+    max-width: 50% !important;
+    pointer-events: none;
 }
 
-.auto-card-link-thumbnail-img {
-    object-fit: cover;
-    height: 100%;
-    flex-shrink: 0;
-}


### PR DESCRIPTION
# This pull request proposes a new style for the card link.

Now `styles.css` uses css variables for colors, font sizes, borders, border radius. This way cards blend in with Obsidian's style and adapt with most community themes. But most importantly they follow the app's dark-light theme.

Title and description are properly truncated, in the same way as they are in Notion. Closes #29.

![image](https://github.com/nekoshita/obsidian-auto-card-link/assets/81334289/42e6286c-8951-4f22-8187-866a89252abd)

![image](https://github.com/nekoshita/obsidian-auto-card-link/assets/81334289/c6f536d4-518c-4fef-b02e-c9a7bb3c969d)

The thumbnail moved on the left to make place for a copy URL button (#45).

