### PR TITLE
Add button to copy card link URL

### DIFF
--- a/src/code_block_processor.ts
+++ b/src/code_block_processor.ts
@@ -1,4 +1,4 @@
-import { App, parseYaml } from "obsidian";
+import { App, parseYaml, Notice, ButtonComponent } from "obsidian";
 
 import { YamlParseError, NoRequiredParamsError } from "src/errors";
 import { LinkMetadata } from "src/interfaces";
@@ -138,6 +138,16 @@ export class CodeBlockProcessor {
     }
     thumbnailImgEl.setAttr("alt", "");
     thumbnailEl.appendChild(thumbnailImgEl);
+
+    new ButtonComponent(containerEl)
+      .setClass("auto-card-link-copy-url")
+      .setClass("clickable-icon")
+      .setIcon("copy")
+      .setTooltip(`Copy URL\n${data.url}`)
+      .onClick(() => {
+        navigator.clipboard.writeText(data.url);
+        new Notice("URL copied to your clipboard")
+      });
 
     return containerEl;
   }

--- a/styles.css
+++ b/styles.css
@@ -114,3 +114,15 @@
     height: 100%;
     flex-shrink: 0;
 }
+
+.auto-card-link-copy-url {
+    background: var(--background-primary-alt);
+    position: absolute;
+    right: 4px;
+    bottom: 4px;
+    z-index: 1;
+
+    .is-phone & {
+        width: var(--input-height);
+    }
+}


### PR DESCRIPTION
This PR follows #44 and should be merged after that.

The button has a tooltip and clicking it generates a `Notice`.

![image](https://github.com/nekoshita/obsidian-auto-card-link/assets/81334289/c83dd645-0e8e-459a-9237-30096abb5e65)

Closes #25.
