### PR TITLE
Add support for local images

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Paste and enhance copied url
 - Enhance selected url
 - Setting for enhancing default paste
+- Support for local images through internal links (`image: "[[image.png]]"`)
 
 
 # `cardlink` syntax


### PR DESCRIPTION
Allow users to use local images, located inside the vault, for the `image` and `favicon` fields of the cardlink. The link is in the wiki style (`[[...]]`). Links must be surrounded by quotes in yaml code blocks, otherwise a `TypeError` will be thrown. I added a specific error message for this.

If the vault contains two images with the same file name the pop up completion menu will help in filling the full path of the desired one.

```cardlink
url: https://obsidian.md
title: "Obsidian - Sharpen your thinking"
description: "Obsidian is the private and flexible note‑taking app that adapts to the way you think."
host: obsidian.md
favicon: https://obsidian.md/favicon.ico
image: "[[folder/subfolder/duplicate.png]]"
```

@xhuajin hope you like it. This also closes #28.


