### PR TITLE
Correct character encoding for metadata parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "iconv-lite": "^0.6.3",
     "obsidian": "^0.14.3",
     "prettier": "^2.6.1",
     "typescript": "^4.6.3"

--- a/src/code_block_generator.ts
+++ b/src/code_block_generator.ts
@@ -4,6 +4,8 @@ import { LinkMetadata } from "src/interfaces";
 import { EditorExtensions } from "src/editor_enhancements";
 import { LinkMetadataParser } from "src/link_metadata_parser";
 
+import * as iconv from 'iconv-lite';
+
 export class CodeBlockGenerator {
   editor: Editor;
 
@@ -76,7 +78,14 @@ export class CodeBlockGenerator {
       return;
     }
 
-    const parser = new LinkMetadataParser(url, res.text);
+    const contentType = this.getCharset(res.headers["content-type"]);
+    const charset = contentType.match(/charset=([\w-]+)/i)?.at(1);
+
+    let text = res.text;
+    if (charset)
+      text = iconv.decode(Buffer.from(res.arrayBuffer), charset)
+
+    const parser = new LinkMetadataParser(url, text);
     return parser.parse();
   }
 


### PR DESCRIPTION
Refactored LinkMetadataParser to handle character encoding specified in the response headers. Added functionality to detect the charset from the Content-Type header and use iconv to decode the response text accordingly. This ensures that non-UTF-8 encoded content is correctly interpreted.